### PR TITLE
Refactor to consistently use common.check

### DIFF
--- a/content/src/policies/rebac.check.rego
+++ b/content/src/policies/rebac.check.rego
@@ -1,20 +1,21 @@
 package rebac.check
 
+import data.todoApp.common.check
+
 # default to a closed system (deny by default)
 default allowed = false
 
 # resource context is expected in the following form:
 # {
-#   "relation": "relation or permission name",
 #   "object_type": "object type that carries the relation or permission",
 #   "object_id": "id of object instance with type of object_type"
+#   "relation": "relation or permission name",
 # }
 allowed {
-  ds.check({
-    "object_type": input.resource.object_type,
-    "object_id": input.resource.object_id,
-    "relation": input.resource.relation,
-    "subject_type": "user",
-    "subject_id": input.user.id
-  })
+  check(
+    input.user,
+    input.resource.relation,
+    input.resource.object_type,
+    input.resource.object_id,
+  )
 }

--- a/content/src/policies/todoApp.DELETE.todos.__id.rego
+++ b/content/src/policies/todoApp.DELETE.todos.__id.rego
@@ -12,7 +12,7 @@ default allowed = false
 # check if the user has the can_delete permission on the resource
 # (example of evaluating a permission on a specific resource)
 allowed {
-  check(user, "can_delete", resource.object_id)
+  check(user, "can_delete", "resource", resource.object_id)
 }
 
 # check if the user is a member of the admin group

--- a/content/src/policies/todoApp.POST.todos.rego
+++ b/content/src/policies/todoApp.POST.todos.rego
@@ -2,24 +2,17 @@ package todoApp.POST.todos
 
 # This policy determines whether the user can create todos
 
+import data.todoApp.common.check
+
 default allowed = false
 
-# Only members of the "resource-creators" instance can create a new Todo.
-#
-# Use the "Check" middleware convention
-# The caller will pass in the following resource context:
-# {
-#   "object_type": "resource-creator",
-#   "object_id": "resource-creators",
-#   "relation": "member"
-# }
+# Only members of the "resource-creators" object can create a new Todo.
 
 allowed {
-  ds.check({
-    "object_type": input.resource.object_type,
-    "object_id": input.resource.object_id,
-    "relation": input.resource.relation,
-    "subject_type": "user",
-    "subject_id": input.user.id
-  })
+  check(
+    input.user,
+    "member",
+    "resource-creator",
+    "resource-creators",
+  )
 }

--- a/content/src/policies/todoApp.PUT.todos.__id.rego
+++ b/content/src/policies/todoApp.PUT.todos.__id.rego
@@ -13,7 +13,7 @@ default allowed = false
 # check if the user has the can_write permission on the resource
 # (example of evaluating a permission on a specific resource)
 allowed {
-  check(user, "can_write", resource.object_id)
+  check(user, "can_write", "resource", resource.object_id)
 }
 
 # check if the user is a member of the allowed groups

--- a/content/src/policies/todoApp.common.rego
+++ b/content/src/policies/todoApp.common.rego
@@ -1,21 +1,17 @@
 package todoApp.common
 
 is_member_of(user, group) := x {
-  x := ds.check({
-    "object_id": group,
-    "object_type": "group",
-    "relation": "member",
-    "subject_id": user.id,
-    "subject_type": "user"
-  })
+  x := check(user, "member", "group", group)
 }
 
-check(user, permission, todo) := x {
+check(user, permission, resource_type, resource_id) := x {
+  # Returns true if the user has the specified permission (or relation) on the
+  # object with the given type and id.
   x := ds.check({
-    "object_id": todo,
-    "object_type": "resource",
+    "object_type": resource_type,
+    "object_id": resource_id,
     "relation": permission,
-    "subject_id": user.id,
-    "subject_type": "user"
+    "subject_type": "user",
+    "subject_id": user.id
   })
 }


### PR DESCRIPTION
The policy has a `todoApp.common` module with a `check()` function that encapsulates a `ds.check()` call but it's not used consistently in all modules.
This PR switches the various `ds.check` calls to `common.check`.
It also constrains the `todoApp.POST.todos` module to check for membership in `resource-creators` instead of allowing arbitrary check parameters provided by the caller. This module isn't used by any of the aserto-demo todo apps. It is there for educational purpose to show how the REST pattern can also be used for the POST endpoint.