### PR TITLE
Constrained check params in todoApp.POST.todos

### DIFF
--- a/content/src/policies/todoApp.POST.todos.rego
+++ b/content/src/policies/todoApp.POST.todos.rego
@@ -5,20 +5,12 @@ package todoApp.POST.todos
 default allowed = false
 
 # Only members of the "resource-creators" instance can create a new Todo.
-#
-# Use the "Check" middleware convention
-# The caller will pass in the following resource context:
-# {
-#   "object_type": "resource-creator",
-#   "object_id": "resource-creators",
-#   "relation": "member"
-# }
 
 allowed {
   ds.check({
-    "object_type": input.resource.object_type,
-    "object_id": input.resource.object_id,
-    "relation": input.resource.relation,
+    "object_type": "resource-creator",
+    "object_id": "resource-creators",
+    "relation": "member",
     "subject_type": "user",
     "subject_id": input.user.id
   })


### PR DESCRIPTION
The `todoApp.POST.todos` module shouldn't allow callers to provide arbitrary arguments to the `ds.check` call.
It's way too easy for an application to get it wrong and end up with broken access control.

This PR hard codes the parameters to check for the `member` relation on `resource-creators`.